### PR TITLE
Refactor/210: 알람 발송 시 식재료 조회 로직 개선

### DIFF
--- a/src/main/java/com/foodkeeper/foodkeeperserver/food/dataaccess/repository/custom/FoodRepositoryCustom.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/food/dataaccess/repository/custom/FoodRepositoryCustom.java
@@ -15,6 +15,8 @@ public interface FoodRepositoryCustom {
 
     List<FoodEntity> findImminentFoods(LocalDate imminentStand, String memberKey);
 
+    List<FoodEntity> findFoodsToNotify(LocalDate targetDate);
+
     List<Long> removeFoods(String memberKey);
 
     Optional<FoodEntity> findByIdAndMemberKey(Long id, String memberKey);

--- a/src/main/java/com/foodkeeper/foodkeeperserver/food/implement/FoodReader.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/food/implement/FoodReader.java
@@ -55,8 +55,7 @@ public class FoodReader {
     }
 
     public List<Food> findFoodsToNotify(LocalDate today) {
-        return foodRepository.findAll().stream()
-                .filter(food -> food.isNotificationDay(today))
+        return foodRepository.findFoodsToNotify(today).stream()
                 .map(FoodEntity::toDomain)
                 .toList();
     }

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSender.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSender.java
@@ -1,14 +1,12 @@
 package com.foodkeeper.foodkeeperserver.notification.implement;
 
 
-import com.foodkeeper.foodkeeperserver.notification.domain.FcmMessage;
 import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
@@ -19,20 +17,13 @@ public class FcmSender {
     private final FcmManager fcmManager;
 
     @Async("fcmExecutor")
-    public void sendNotification(FcmMessage sender) {
-
-        Map<String, String> data = new HashMap<>();
-        data.put("foodName", sender.foodName());
-        data.put("remainingDays", String.valueOf(sender.remainingDays()));
-        data.put("title", sender.title());
-        data.put("type", sender.type());
-
+    public void sendNotification(String fcmToken, Map<String, String> data) {
         AndroidConfig androidConfig = AndroidConfig.builder()
                 .setPriority(AndroidConfig.Priority.HIGH)
                 .build();
 
         Message message = Message.builder()
-                .setToken(sender.fcmToken())
+                .setToken(fcmToken)
                 .putAllData(data)
                 .setAndroidConfig(androidConfig)
                 .build();
@@ -45,10 +36,10 @@ public class FcmSender {
             if (errorCode == MessagingErrorCode.UNREGISTERED ||
                     errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
 
-                log.warn("[FCM 만료 토큰 삭제] fcmToken: {}", sender.fcmToken());
-                fcmManager.remove(sender.fcmToken());
+                log.warn("[FCM 만료 토큰 삭제] fcmToken: {}", fcmToken);
+                fcmManager.remove(fcmToken);
             }
-            log.error("[FCM 전송 실패] fcmToken: {}, error: {}", sender.fcmToken(), e.getMessage());
+            log.error("[FCM 전송 실패] fcmToken: {}, error: {}", fcmToken, e.getMessage());
         }
     }
 

--- a/src/main/java/com/foodkeeper/foodkeeperserver/test/controller/TestController.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/test/controller/TestController.java
@@ -11,6 +11,7 @@ import com.foodkeeper.foodkeeperserver.member.domain.NewMember;
 import com.foodkeeper.foodkeeperserver.member.domain.Nickname;
 import com.foodkeeper.foodkeeperserver.member.domain.enums.SignUpType;
 import com.foodkeeper.foodkeeperserver.member.implement.MemberRegistrar;
+import com.foodkeeper.foodkeeperserver.notification.business.FoodNotificationService;
 import com.foodkeeper.foodkeeperserver.support.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,14 +29,22 @@ import java.util.List;
 @Profile("!prod")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/test-sign-in")
-public class TestSignInController {
+@RequestMapping("/api/v1/test")
+public class TestController {
 
     private final MemberRegistrar memberRegistrar;
     private final JwtGenerator jwtGenerator;
+    private final FoodNotificationService foodNotificationService;
 
     @NullMarked
-    @PostMapping
+    @PostMapping("/trigger/expiry-alarm")
+    public ResponseEntity<ApiResponse<Void>> triggerExpiryAlarm() {
+        foodNotificationService.sendExpiryAlarm();
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @NullMarked
+    @PostMapping("/sign-in")
     public ResponseEntity<ApiResponse<AuthTokenResponse>> testSignIn(@RequestBody TestSingInRequest request) {
         NewMember newMember = NewMember.builder()
                 .email(new Email(request.email()))

--- a/src/test/java/com/foodkeeper/foodkeeperserver/food/dataaccess/repository/FoodRepositoryTest.java
+++ b/src/test/java/com/foodkeeper/foodkeeperserver/food/dataaccess/repository/FoodRepositoryTest.java
@@ -104,7 +104,7 @@ class FoodRepositoryTest extends RepositoryTest {
     }
 
     @Test
-    @DisplayName("유통기한(expiryDate)로 부터 imminentStand일 이내로 남은 Food들을 조회한다.")
+    @DisplayName("유통기한(expiryDate)으로 부터 imminentStand일 이내로 남은 Food들을 조회한다.")
     void findFoodsWithin7DaysOfItsExpiryDate() {
         // given
         String memberKey = "memberKey";
@@ -128,6 +128,36 @@ class FoodRepositoryTest extends RepositoryTest {
 
         // when
         List<FoodEntity> imminentFoods = foodRepository.findImminentFoods(imminentStand, memberKey);
+
+        // then
+        assertThat(imminentFoods).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("목표 날짜가 유통기한 이전 알람 날짜와 같은 식재료들을 조회한다.")
+    void findFoodsThatTargetDateEqualsToAlarmDate() {
+        // given
+        String memberKey = "memberKey";
+        LocalDate targetDate = LocalDate.now();
+        List<Pair<String, LocalDate>> foodInfos = List.of(
+                new Pair<>("food1", LocalDate.now().plusDays(2)),
+                new Pair<>("food2", LocalDate.now().plusDays(3)),
+                new Pair<>("food3", LocalDate.now().plusDays(2))
+        );
+        foodInfos.forEach(foodInfo ->
+                em.persist(FoodEntity.builder()
+                        .name(foodInfo.first)
+                        .imageUrl("https://test.com/image.jpg")
+                        .storageMethod(StorageMethod.FROZEN)
+                        .expiryDate(foodInfo.second)
+                        .expiryAlarmDays(2)
+                        .memo("")
+                        .selectedCategoryCount(1)
+                        .memberKey(memberKey)
+                        .build()));
+
+        // when
+        List<FoodEntity> imminentFoods = foodRepository.findFoodsToNotify(targetDate);
 
         // then
         assertThat(imminentFoods).hasSize(2);

--- a/src/test/java/com/foodkeeper/foodkeeperserver/notification/business/FoodNotificationServiceTest.java
+++ b/src/test/java/com/foodkeeper/foodkeeperserver/notification/business/FoodNotificationServiceTest.java
@@ -3,7 +3,6 @@ package com.foodkeeper.foodkeeperserver.notification.business;
 import com.foodkeeper.foodkeeperserver.food.domain.Food;
 import com.foodkeeper.foodkeeperserver.food.fixture.FoodFixture;
 import com.foodkeeper.foodkeeperserver.food.implement.FoodReader;
-import com.foodkeeper.foodkeeperserver.notification.domain.FcmMessage;
 import com.foodkeeper.foodkeeperserver.notification.domain.MemberFcmTokens;
 import com.foodkeeper.foodkeeperserver.notification.implement.FcmManager;
 import com.foodkeeper.foodkeeperserver.notification.implement.FcmSender;
@@ -21,6 +20,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -48,14 +48,15 @@ public class FoodNotificationServiceTest {
 
         MemberFcmTokens memberFcmTokens = new MemberFcmTokens(Map.of(memberKey, List.of(token)));
         given(fcmManager.findTokens(anySet())).willReturn(memberFcmTokens);
-        //when
-        foodNotificationService.sendExpiryAlarm();
-        //then
-        ArgumentCaptor<FcmMessage> captor = ArgumentCaptor.forClass(FcmMessage.class);
-        verify(fcmSender).sendNotification(captor.capture());
 
-        assertThat(captor.getValue().title()).isEqualTo("우유 D-1");
-        assertThat(captor.getValue().fcmToken()).isEqualTo(token);
+        // when
+        foodNotificationService.sendExpiryAlarm();
+
+        // then
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(fcmSender).sendNotification(eq(token), captor.capture());
+
+        assertThat(captor.getValue().get("title")).isEqualTo("우유 D-1");
     }
 
     @Test
@@ -77,8 +78,9 @@ public class FoodNotificationServiceTest {
         // when
         foodNotificationService.sendExpiryAlarm();
 
-        ArgumentCaptor<FcmMessage> captor = ArgumentCaptor.forClass(FcmMessage.class);
-        verify(fcmSender).sendNotification(captor.capture());
-        assertThat(captor.getValue().title()).isEqualTo("우유 외 1건");
+        // then
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(fcmSender).sendNotification(eq(token), captor.capture());
+        assertThat(captor.getValue().get("title")).isEqualTo("우유 외 1건");
     }
 }


### PR DESCRIPTION
## 요약
알람 발송 시 식재료 조회 로직 개선

## 변경사항(상세)
- 식재료 조회 query 조건 추가 `findAll()` -> `findFoodsToNotify()`