### PR TITLE
Refactor/214: 개발서버 DB Migration

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,16 @@ services:
         -Dcom.sun.management.jmxremote.authenticate=false
         -Dcom.sun.management.jmxremote.ssl=false
         -Djava.rmi.server.hostname=${JMX_HOST}
+    command: >
+      java
+      -Dcom.sun.management.jmxremote
+      -Dcom.sun.management.jmxremote.port=9010
+      -Dcom.sun.management.jmxremote.rmi.port=9011
+      -Dcom.sun.management.jmxremote.local.only=false
+      -Dcom.sun.management.jmxremote.authenticate=false
+      -Dcom.sun.management.jmxremote.ssl=false
+      -Djava.rmi.server.hostname=${JMX_HOST}
+      -jar app.jar
     ports:
       - "8080:8080"
       - "9010:9010"
@@ -55,27 +65,6 @@ services:
       - ./:/app/local
       - /var/log/kitchen-log:/var/log/kitchen-log
 
-  mysql:
-    image: mysql:8.0.44-debian
-    container_name: mysql
-    restart: always
-    ports:
-      - "3306:3306"
-    volumes:
-      - ./db/mysql/data:/var/lib/mysql
-      - ./db/mysql/init:/docker-entrypoint-initdb.d
-    environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      TZ: Asia/Seoul
-    command: [
-       "--character-set-server=utf8mb4",
-       "--collation-server=utf8mb4_unicode_ci"
-    ]
-    networks:
-      - kitchen-log
   promtail:
     image: grafana/promtail:latest
     container_name: promtail


### PR DESCRIPTION
## 요약
개발서버 DB Migration

## 변경사항(상세)
- migration 이후 dev docker compose에서 mysql 구문 삭제