### PR TITLE
Refactor/222 : firebase batch 전송 방식으로 변경

### DIFF
--- a/src/main/java/com/foodkeeper/foodkeeperserver/common/domain/Cursorable.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/common/domain/Cursorable.java
@@ -1,7 +1,7 @@
 package com.foodkeeper.foodkeeperserver.common.domain;
 
 public record Cursorable<T>(T cursor, Integer limit) {
-    private static final int SYSTEM_MAX = 500;
+    private static final int SYSTEM_MAX = 450;
 
     public Cursorable(T cursor, Integer limit) {
         this.cursor = cursor;

--- a/src/main/java/com/foodkeeper/foodkeeperserver/config/db/AsyncConfig.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/config/db/AsyncConfig.java
@@ -2,10 +2,12 @@ package com.foodkeeper.foodkeeperserver.config.db;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.support.TaskExecutorAdapter;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 @Configuration
 @EnableAsync
@@ -13,11 +15,7 @@ public class AsyncConfig {
 
     @Bean(name = "fcmExecutor")
     public Executor fcmExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(30);
-        executor.setThreadNamePrefix("Fcm-");
-        executor.initialize();
-        return executor;
+        return new TaskExecutorAdapter(Executors.newVirtualThreadPerTaskExecutor());
     }
 
     @Bean(name = "imageExecutor")

--- a/src/main/java/com/foodkeeper/foodkeeperserver/food/dataaccess/repository/custom/FoodRepositoryCustomImpl.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/food/dataaccess/repository/custom/FoodRepositoryCustomImpl.java
@@ -71,8 +71,8 @@ public class FoodRepositoryCustomImpl extends QuerydslRepositorySupport implemen
                         eqExpiryAlarmDays(targetDate),
                         ltCursor(cursorable.cursor())
                 )
-                .limit(cursorable.limit() + 1)
                 .orderBy(foodEntity.id.desc())
+                .limit(cursorable.limit() + 1)
                 .fetch();
         return new SliceObject<>(content, cursorable, hasNext(cursorable, content));
     }

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/business/FcmTokenService.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/business/FcmTokenService.java
@@ -1,9 +1,18 @@
 package com.foodkeeper.foodkeeperserver.notification.business;
 
 import com.foodkeeper.foodkeeperserver.notification.implement.FcmManager;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.SendResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FcmTokenService {

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/business/FoodNotificationService.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/business/FoodNotificationService.java
@@ -4,9 +4,11 @@ import com.foodkeeper.foodkeeperserver.common.domain.Cursorable;
 import com.foodkeeper.foodkeeperserver.common.domain.SliceObject;
 import com.foodkeeper.foodkeeperserver.food.domain.Food;
 import com.foodkeeper.foodkeeperserver.food.implement.FoodReader;
+import com.foodkeeper.foodkeeperserver.notification.domain.AlarmMessages;
 import com.foodkeeper.foodkeeperserver.notification.domain.MemberFcmTokens;
 import com.foodkeeper.foodkeeperserver.notification.implement.FcmManager;
 import com.foodkeeper.foodkeeperserver.notification.implement.FcmSender;
+import com.google.firebase.messaging.Message;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.awt.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +30,6 @@ public class FoodNotificationService {
     private final FcmSender fcmSender;
     private final FoodReader foodReader;
     private final FcmManager fcmManager;
-    private static final String type = "EXPIRATION";
     private static final int limit = 500;
 
     @Scheduled(cron = "0 0 12 * * *")
@@ -35,11 +37,11 @@ public class FoodNotificationService {
         LocalDate today = LocalDate.now();
         log.info("[Expiry Alarm] 유통기한 알림 전송 시작");
 
-        Long currentCursor = 0L;
+        Long currentCursor = null;
         boolean hasNext = true;
 
-        while(hasNext) {
-            SliceObject<Food> foods = foodReader.findFoodsToNotify(new Cursorable<>(currentCursor, limit),today);
+        while (hasNext) {
+            SliceObject<Food> foods = foodReader.findFoodsToNotify(new Cursorable<>(currentCursor, limit), today);
             List<Food> alarmFoods = foods.content();
 
             if (alarmFoods.isEmpty()) {
@@ -51,15 +53,10 @@ public class FoodNotificationService {
                     .collect(Collectors.groupingBy(Food::memberKey));
 
             MemberFcmTokens memberFcmTokens = fcmManager.findTokens(foodsByMember.keySet());
-            foodsByMember.forEach((memberKey, memberFoods) -> {
-                if (!memberFcmTokens.hasTokens(memberKey)) {
-                    return;
-                }
 
-                Map<String, String> fcmMessage = createFcmMessage(memberFoods, today);
-                memberFcmTokens.getTokensByMember(memberKey)
-                        .forEach(token -> fcmSender.sendNotification(token, fcmMessage));
-            });
+            AlarmMessages messages = AlarmMessages.create(foodsByMember, memberFcmTokens, today);
+
+            fcmSender.sendNotification(messages);
 
             hasNext = foods.hasNext();
             if (hasNext) {
@@ -69,28 +66,6 @@ public class FoodNotificationService {
 
             log.info("[Expiry Alarm] 전송 요청 완료. 대상 음식 수: {}", alarmFoods.size());
         }
-
-
-
     }
 
-    private Map<String, String> createFcmMessage(List<Food> foods, LocalDate today) {
-        Map<String, String> data = new HashMap<>();
-        String title;
-        Food firstFood = foods.getFirst();
-        long remainDays = firstFood.calculateRemainDay(today);
-
-        if (foods.size() == 1) {
-            title = "%s D-%d".formatted(firstFood.name(), remainDays);
-        } else {
-            title = "%s 외 %d건".formatted(firstFood.name(), foods.size() - 1);
-        }
-
-        data.put("foodName", firstFood.name());
-        data.put("remainingDays", String.valueOf(remainDays));
-        data.put("title", title);
-        data.put("type", type);
-
-        return data;
-    }
 }

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/business/FoodNotificationService.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/business/FoodNotificationService.java
@@ -30,7 +30,7 @@ public class FoodNotificationService {
     private final FcmSender fcmSender;
     private final FoodReader foodReader;
     private final FcmManager fcmManager;
-    private static final int limit = 500;
+    private static final int limit = 450;
 
     @Scheduled(cron = "0 0 12 * * *")
     public void sendExpiryAlarm() {

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/dataaccess/repository/custom/FcmTokenCustomRepository.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/dataaccess/repository/custom/FcmTokenCustomRepository.java
@@ -15,4 +15,6 @@ public interface FcmTokenCustomRepository {
     Optional<FcmTokenEntity> findByToken(String token);
 
     void deleteByToken(String token);
+
+    void deleteAll(List<String> fcmTokens);
 }

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/dataaccess/repository/custom/FcmTokenCustomRepositoryImpl.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/dataaccess/repository/custom/FcmTokenCustomRepositoryImpl.java
@@ -53,6 +53,17 @@ public class FcmTokenCustomRepositoryImpl extends QuerydslRepositorySupport impl
         getEntityManager().clear();
     }
 
+    @Override
+    public void deleteAll(List<String> fcmTokens) {
+        if(fcmTokens.isEmpty()) return;
+        update(fcmTokenEntity)
+                .set(fcmTokenEntity.status, EntityStatus.DELETED)
+                .where(fcmTokenEntity.token.in(fcmTokens))
+                .execute();
+
+        getEntityManager().clear();
+    }
+
     private static BooleanExpression isActive() {
         return fcmTokenEntity.status.eq(EntityStatus.ACTIVE);
     }

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/domain/AlarmMessages.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/domain/AlarmMessages.java
@@ -1,0 +1,75 @@
+package com.foodkeeper.foodkeeperserver.notification.domain;
+
+import com.foodkeeper.foodkeeperserver.food.domain.Food;
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.Message;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public record AlarmMessages(List<Message> messages, List<String> tokens) {
+    private static final String type = "EXPIRATION";
+
+    public AlarmMessages(List<Message> messages, List<String> tokens) {
+        this.messages = List.copyOf(messages);
+        this.tokens = List.copyOf(tokens);
+    }
+
+    public static AlarmMessages create(Map<String, List<Food>> foodsByMember,
+                                       MemberFcmTokens memberFcmTokens,
+                                       LocalDate today) {
+        List<Message> messages = new ArrayList<>();
+        List<String> tokens = new ArrayList<>();
+
+        AndroidConfig androidConfig = AndroidConfig.builder()
+                .setPriority(AndroidConfig.Priority.HIGH)
+                .build();
+
+        foodsByMember.forEach((memberKey, memberFoods) -> {
+            if (!memberFcmTokens.hasTokens(memberKey)) {
+                return;
+            }
+
+            Map<String, String> fcmData = createAlarmMessage(memberFoods, today);
+
+            memberFcmTokens.getTokensByMember(memberKey).forEach(token -> {
+                messages.add(Message.builder()
+                        .setToken(token)
+                        .putAllData(fcmData)
+                        .setAndroidConfig(androidConfig)
+                        .build());
+                tokens.add(token);
+            });
+        });
+
+        return new AlarmMessages(messages, tokens);
+    }
+
+
+    private static Map<String, String> createAlarmMessage(List<Food> foods, LocalDate today) {
+        Map<String, String> data = new HashMap<>();
+        String title;
+        Food firstFood = foods.getFirst();
+        long remainDays = firstFood.calculateRemainDay(today);
+
+        if (foods.size() == 1) {
+            title = "%s D-%d".formatted(firstFood.name(), remainDays);
+        } else {
+            title = "%s 외 %d건".formatted(firstFood.name(), foods.size() - 1);
+        }
+
+        data.put("foodName", firstFood.name());
+        data.put("remainingDays", String.valueOf(remainDays));
+        data.put("title", title);
+        data.put("type", type);
+
+        return data;
+    }
+
+}
+

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmManager.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmManager.java
@@ -55,4 +55,9 @@ public class FcmManager {
     public void removeFcmTokens(String memberKey) {
         fcmRepository.deleteFcmTokens(memberKey);
     }
+
+    @Transactional
+    public void removeAll(List<String> invalidTokens) {
+        fcmRepository.deleteAll(invalidTokens);
+    }
 }

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSender.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSender.java
@@ -24,6 +24,7 @@ public class FcmSender {
         List<Message> messages = alarmMessages.messages();
         List<String> tokens = alarmMessages.tokens();
 
+//        FirebaseMessaging.getInstance().sendEachAsync(messages, true);
         try {
             BatchResponse batchResponse = FirebaseMessaging.getInstance().sendEach(messages, true);
             List<String> invalidTokens = extractInvalidTokens(tokens,batchResponse);

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSender.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSender.java
@@ -1,12 +1,15 @@
 package com.foodkeeper.foodkeeperserver.notification.implement;
 
 
+import com.foodkeeper.foodkeeperserver.notification.domain.AlarmMessages;
 import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -17,31 +20,39 @@ public class FcmSender {
     private final FcmManager fcmManager;
 
     @Async("fcmExecutor")
-    public void sendNotification(String fcmToken, Map<String, String> data) {
-        AndroidConfig androidConfig = AndroidConfig.builder()
-                .setPriority(AndroidConfig.Priority.HIGH)
-                .build();
+    public void sendNotification(AlarmMessages alarmMessages) {
+        List<Message> messages = alarmMessages.messages();
+        List<String> tokens = alarmMessages.tokens();
 
-        Message message = Message.builder()
-                .setToken(fcmToken)
-                .putAllData(data)
-                .setAndroidConfig(androidConfig)
-                .build();
         try {
-            FirebaseMessaging.getInstance().send(message);
-
+            BatchResponse batchResponse = FirebaseMessaging.getInstance().sendEach(messages, true);
+            List<String> invalidTokens = extractInvalidTokens(tokens,batchResponse);
+            fcmManager.removeAll(invalidTokens);
         } catch (FirebaseMessagingException e) {
-            MessagingErrorCode errorCode = e.getMessagingErrorCode();
-
-            if (errorCode == MessagingErrorCode.UNREGISTERED ||
-                    errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
-
-                log.warn("[FCM 만료 토큰 삭제] fcmToken: {}", fcmToken);
-                fcmManager.remove(fcmToken);
-            }
-            log.error("[FCM 전송 실패] fcmToken: {}, error: {}", fcmToken, e.getMessage());
+            log.error("[FCM 전송 실패] error: {}", e.getMessage());
         }
     }
 
+    private List<String> extractInvalidTokens(List<String> tokens, BatchResponse batchResponse) {
+        List<SendResponse> responses = batchResponse.getResponses();
+        List<String> invalidTokens = new ArrayList<>();
 
+        for (int i = 0; i < responses.size(); i++) {
+            SendResponse response = responses.get(i);
+
+            if (!response.isSuccessful()) {
+                FirebaseMessagingException exception = response.getException();
+                MessagingErrorCode errorCode = exception.getMessagingErrorCode();
+                String failedToken = tokens.get(i);
+
+                if (errorCode == MessagingErrorCode.UNREGISTERED ||
+                        errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
+                    invalidTokens.add(failedToken);
+                } else {
+                    log.error("[FCM 개별 전송 실패] token: {}, error: {}", failedToken, exception.getMessage());
+                }
+            }
+        }
+        return invalidTokens;
+    }
 }

--- a/src/test/java/com/foodkeeper/foodkeeperserver/notification/business/FoodNotificationServiceTest.java
+++ b/src/test/java/com/foodkeeper/foodkeeperserver/notification/business/FoodNotificationServiceTest.java
@@ -5,6 +5,7 @@ import com.foodkeeper.foodkeeperserver.common.domain.SliceObject;
 import com.foodkeeper.foodkeeperserver.food.domain.Food;
 import com.foodkeeper.foodkeeperserver.food.fixture.FoodFixture;
 import com.foodkeeper.foodkeeperserver.food.implement.FoodReader;
+import com.foodkeeper.foodkeeperserver.notification.domain.AlarmMessages;
 import com.foodkeeper.foodkeeperserver.notification.domain.MemberFcmTokens;
 import com.foodkeeper.foodkeeperserver.notification.implement.FcmManager;
 import com.foodkeeper.foodkeeperserver.notification.implement.FcmSender;
@@ -38,7 +39,7 @@ public class FoodNotificationServiceTest {
     FcmSender fcmSender;
 
     @Test
-    @DisplayName("식재료가 1개일 떄 단일 메시지 알림 전송")
+    @DisplayName("식재료가 1개일 때 AlarmMessages가 정상적으로 생성되어 전송 호출됨")
     void send_expiryAlarm_SUCCESS() {
         //given
         String memberKey = "memberKey";
@@ -46,7 +47,8 @@ public class FoodNotificationServiceTest {
         LocalDate today = LocalDate.now();
         Food food = FoodFixture.createFood(1L);
 
-        given(foodReader.findFoodsToNotify(any(Cursorable.class),eq(today))).willReturn(new SliceObject<>(List.of(food),new Cursorable<>(0,1),false));
+        given(foodReader.findFoodsToNotify(any(Cursorable.class), eq(today)))
+                .willReturn(new SliceObject<>(List.of(food), new Cursorable<>(0, 1), false));
 
         MemberFcmTokens memberFcmTokens = new MemberFcmTokens(Map.of(memberKey, List.of(token)));
         given(fcmManager.findTokens(anySet())).willReturn(memberFcmTokens);
@@ -55,25 +57,28 @@ public class FoodNotificationServiceTest {
         foodNotificationService.sendExpiryAlarm();
 
         // then
-        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
-        verify(fcmSender).sendNotification(eq(token), captor.capture());
+        ArgumentCaptor<AlarmMessages> captor = ArgumentCaptor.forClass(AlarmMessages.class);
+        verify(fcmSender).sendNotification(captor.capture());
 
-        assertThat(captor.getValue().get("title")).isEqualTo("우유 D-1");
+        AlarmMessages capturedAlarmMessages = captor.getValue();
+
+        assertThat(capturedAlarmMessages.tokens()).containsExactly(token);
+        assertThat(capturedAlarmMessages.messages()).hasSize(1);
     }
 
     @Test
-    @DisplayName("한 사용자의 식재료가 여러 건 메시지 알림 전송")
+    @DisplayName("한 사용자의 식재료가 여러 건일 때 AlarmMessages가 정상적으로 생성되어 전송 호출됨")
     void sendMultipleAlarm_SUCCESS() {
         // given
         String memberKey = "memberKey";
         String token = "token";
         LocalDate today = LocalDate.now();
 
-        // 같은 사용자
         Food food1 = FoodFixture.createFood(1L);
         Food food2 = FoodFixture.createFood(2L);
 
-        given(foodReader.findFoodsToNotify(any(Cursorable.class),eq(today))).willReturn(new SliceObject<>(List.of(food1,food2),new Cursorable<>(0,50),false));
+        given(foodReader.findFoodsToNotify(any(Cursorable.class), eq(today)))
+                .willReturn(new SliceObject<>(List.of(food1, food2), new Cursorable<>(0, 50), false));
 
         MemberFcmTokens fcmTokens = new MemberFcmTokens(Map.of(memberKey, List.of(token)));
         given(fcmManager.findTokens(anySet())).willReturn(fcmTokens);
@@ -82,8 +87,11 @@ public class FoodNotificationServiceTest {
         foodNotificationService.sendExpiryAlarm();
 
         // then
-        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
-        verify(fcmSender).sendNotification(eq(token), captor.capture());
-        assertThat(captor.getValue().get("title")).isEqualTo("우유 외 1건");
+        ArgumentCaptor<AlarmMessages> captor = ArgumentCaptor.forClass(AlarmMessages.class);
+        verify(fcmSender).sendNotification(captor.capture());
+
+        AlarmMessages capturedAlarmMessages = captor.getValue();
+        assertThat(capturedAlarmMessages.tokens()).containsExactly(token);
+        assertThat(capturedAlarmMessages.messages()).hasSize(1);
     }
 }

--- a/src/test/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSenderTest.java
+++ b/src/test/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSenderTest.java
@@ -1,10 +1,8 @@
 package com.foodkeeper.foodkeeperserver.notification.implement;
 
 import com.foodkeeper.foodkeeperserver.notification.dataaccess.repository.FcmRepository;
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.MessagingErrorCode;
+import com.foodkeeper.foodkeeperserver.notification.domain.AlarmMessages;
+import com.google.firebase.messaging.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +13,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.BDDMockito.given;
@@ -36,45 +35,58 @@ public class FcmSenderTest {
     }
 
     @Test
-    @DisplayName("알림 전송 요청 시 FirebaseMessaging 호출 성공")
+    @DisplayName("알림 전송 요청 시 FirebaseMessaging 다중 전송(sendEach) 호출 성공")
     void sendNotification_SUCCESS() throws Exception {
         try (MockedStatic<FirebaseMessaging> mockFirebase = mockStatic(FirebaseMessaging.class)) {
             // given
-            Map<String, String> data = new HashMap<>();
-
             FirebaseMessaging messaging = mock(FirebaseMessaging.class);
             mockFirebase.when(FirebaseMessaging::getInstance).thenReturn(messaging);
 
+            Message message = Message.builder().setToken("validToken").build();
+            AlarmMessages alarmMessages = new AlarmMessages(List.of(message), List.of("validToken"));
+
+            BatchResponse batchResponse = mock(BatchResponse.class);
+            SendResponse sendResponse = mock(SendResponse.class);
+
+            given(messaging.sendEach(anyList(), eq(true))).willReturn(batchResponse);
+            given(batchResponse.getResponses()).willReturn(List.of(sendResponse));
+            given(sendResponse.isSuccessful()).willReturn(true);
+
             // when
-            fcmSender.sendNotification("fcmToken", data);
+            fcmSender.sendNotification(alarmMessages);
 
             // then
-            verify(messaging, times(1)).send(any(Message.class));
-            verify(fcmRepository, never()).deleteByToken(anyString());
+            verify(messaging, times(1)).sendEach(anyList(), eq(true));
         }
     }
 
     @Test
-    @DisplayName("만료된 토큰 에러코드 반환 시 토큰 삭제 성공")
+    @DisplayName("만료된 토큰(UNREGISTERED) 에러코드 반환 시 토큰 삭제 매니저 호출")
     void sendNotification_FAIL_DELETE() throws Exception {
         try (MockedStatic<FirebaseMessaging> mockFirebase = mockStatic(FirebaseMessaging.class)) {
-            String expiredToken = "token";
-            Map<String, String> data = new HashMap<>();
-
+            // given
             FirebaseMessaging messaging = mock(FirebaseMessaging.class);
             mockFirebase.when(FirebaseMessaging::getInstance).thenReturn(messaging);
 
+            String expiredToken = "expiredToken";
+            Message message = Message.builder().setToken(expiredToken).build();
+            AlarmMessages alarmMessages = new AlarmMessages(List.of(message), List.of(expiredToken));
+
+            BatchResponse batchResponse = mock(BatchResponse.class);
+            SendResponse sendResponse = mock(SendResponse.class);
             FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+
+            given(messaging.sendEach(anyList(), eq(true))).willReturn(batchResponse);
+            given(batchResponse.getResponses()).willReturn(List.of(sendResponse));
+            given(sendResponse.isSuccessful()).willReturn(false);
+            given(sendResponse.getException()).willReturn(exception);
             given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.UNREGISTERED);
-            doThrow(exception).when(messaging).send(any(Message.class));
 
-            //when
-            fcmSender.sendNotification(expiredToken, data);
-            //then
-            verify(fcmRepository, times(1)).deleteByToken(expiredToken);
+            // when
+            fcmSender.sendNotification(alarmMessages);
 
+            // then
+            verify(fcmRepository, times(1)).deleteAll(List.of(expiredToken));
         }
-
-
     }
 }


### PR DESCRIPTION
## 요약
처리량 극대화 및 지연시간 단축을 위해서 인덱스와 firebase 내의 sendEach() 메서드를 활용하여 스프링 배치를 활용하지 않고 한번에 많은 데이터 알림 전송 처리
## 변경사항(상세)