### PR TITLE
feature[#224]: firebase 알림 전송 실패 시 재시도 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.aspectj:aspectjweaver'
+    implementation 'org.springframework.retry:spring-retry:2.0.11'
+
 
     // DB
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/foodkeeper/foodkeeperserver/config/db/AsyncConfig.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/config/db/AsyncConfig.java
@@ -3,14 +3,15 @@ package com.foodkeeper.foodkeeperserver.config.db;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.support.TaskExecutorAdapter;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 @Configuration
 @EnableAsync
+@EnableRetry
 public class AsyncConfig {
 
     @Bean(name = "fcmExecutor")
@@ -20,12 +21,6 @@ public class AsyncConfig {
 
     @Bean(name = "imageExecutor")
     public Executor imageExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(30);
-        executor.setQueueCapacity(80);
-        executor.setThreadNamePrefix("S3-");
-        executor.initialize();
-        return executor;
+        return new TaskExecutorAdapter(Executors.newVirtualThreadPerTaskExecutor());
     }
 }

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmRetryExecutor.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmRetryExecutor.java
@@ -1,0 +1,27 @@
+package com.foodkeeper.foodkeeperserver.notification.implement;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class FcmRetryExecutor {
+
+    @Retryable(
+            retryFor = FirebaseMessagingException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2.0)
+    )
+    public BatchResponse sendEach(List<Message> messages) throws FirebaseMessagingException {
+        log.info("[FCM 전송 시도] 대상: {}건", messages.size());
+        return FirebaseMessaging.getInstance().sendEach(messages, true);
+    }
+}

--- a/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSender.java
+++ b/src/main/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSender.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -18,19 +17,27 @@ import java.util.Map;
 public class FcmSender {
 
     private final FcmManager fcmManager;
+    private final FcmRetryExecutor fcmRetryExecutor;
 
     @Async("fcmExecutor")
     public void sendNotification(AlarmMessages alarmMessages) {
         List<Message> messages = alarmMessages.messages();
         List<String> tokens = alarmMessages.tokens();
 
-//        FirebaseMessaging.getInstance().sendEachAsync(messages, true);
         try {
-            BatchResponse batchResponse = FirebaseMessaging.getInstance().sendEach(messages, true);
-            List<String> invalidTokens = extractInvalidTokens(tokens,batchResponse);
+            BatchResponse batchResponse = fcmRetryExecutor.sendEach(messages);
+
+            List<String> invalidTokens = extractInvalidTokens(tokens, batchResponse);
             fcmManager.removeAll(invalidTokens);
+
+            List<Message> retryableMessages = extractRetryableMessages(messages, tokens, batchResponse);
+            if (!retryableMessages.isEmpty()) {
+                log.info("[FCM 재시도] 네트워크 오류로 실패한 {}건 재시도", retryableMessages.size());
+                fcmRetryExecutor.sendEach(retryableMessages);
+            }
+
         } catch (FirebaseMessagingException e) {
-            log.error("[FCM 전송 실패] error: {}", e.getMessage());
+            log.warn("[FCM 전송 최종 실패] error: {}", e.getMessage());
         }
     }
 
@@ -42,18 +49,37 @@ public class FcmSender {
             SendResponse response = responses.get(i);
 
             if (!response.isSuccessful()) {
-                FirebaseMessagingException exception = response.getException();
-                MessagingErrorCode errorCode = exception.getMessagingErrorCode();
-                String failedToken = tokens.get(i);
+                MessagingErrorCode errorCode = response.getException().getMessagingErrorCode();
 
                 if (errorCode == MessagingErrorCode.UNREGISTERED ||
                         errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
-                    invalidTokens.add(failedToken);
-                } else {
-                    log.error("[FCM 개별 전송 실패] token: {}, error: {}", failedToken, exception.getMessage());
+                    invalidTokens.add(tokens.get(i));
                 }
             }
         }
         return invalidTokens;
+    }
+
+    private List<Message> extractRetryableMessages(List<Message> messages, List<String> tokens, BatchResponse batchResponse) {
+        List<SendResponse> responses = batchResponse.getResponses();
+        List<Message> retryableMessages = new ArrayList<>();
+
+        for (int i = 0; i < responses.size(); i++) {
+            SendResponse response = responses.get(i);
+
+            if (!response.isSuccessful()) {
+                MessagingErrorCode errorCode = response.getException().getMessagingErrorCode();
+
+                if (errorCode == MessagingErrorCode.UNAVAILABLE ||
+                        errorCode == MessagingErrorCode.INTERNAL ||
+                        errorCode == MessagingErrorCode.QUOTA_EXCEEDED) {
+                    retryableMessages.add(messages.get(i));
+                } else if (errorCode != MessagingErrorCode.UNREGISTERED &&
+                        errorCode != MessagingErrorCode.INVALID_ARGUMENT) {
+                    log.error("[FCM 개별 전송 실패] token: {}, error: {}", tokens.get(i), response.getException().getMessage());
+                }
+            }
+        }
+        return retryableMessages;
     }
 }

--- a/src/test/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSenderTest.java
+++ b/src/test/java/com/foodkeeper/foodkeeperserver/notification/implement/FcmSenderTest.java
@@ -1,21 +1,17 @@
 package com.foodkeeper.foodkeeperserver.notification.implement;
 
-import com.foodkeeper.foodkeeperserver.notification.dataaccess.repository.FcmRepository;
 import com.foodkeeper.foodkeeperserver.notification.domain.AlarmMessages;
 import com.google.firebase.messaging.*;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -26,67 +22,97 @@ public class FcmSenderTest {
     private FcmSender fcmSender;
 
     @Mock
-    private FcmRepository fcmRepository;
+    private FcmManager fcmManager;
 
-    @BeforeEach
-    void setUp() {
-        FcmManager fcmManager = new FcmManager(fcmRepository);
-        fcmSender = new FcmSender(fcmManager);
-    }
+    @Mock
+    private FcmRetryExecutor fcmRetryExecutor;
 
     @Test
-    @DisplayName("알림 전송 요청 시 FirebaseMessaging 다중 전송(sendEach) 호출 성공")
+    @DisplayName("알림 전송 요청 시 fcmRetryExecutor.sendEach 호출 성공")
     void sendNotification_SUCCESS() throws Exception {
-        try (MockedStatic<FirebaseMessaging> mockFirebase = mockStatic(FirebaseMessaging.class)) {
-            // given
-            FirebaseMessaging messaging = mock(FirebaseMessaging.class);
-            mockFirebase.when(FirebaseMessaging::getInstance).thenReturn(messaging);
+        // given
+        Message message = Message.builder().setToken("validToken").build();
+        AlarmMessages alarmMessages = new AlarmMessages(List.of(message), List.of("validToken"));
 
-            Message message = Message.builder().setToken("validToken").build();
-            AlarmMessages alarmMessages = new AlarmMessages(List.of(message), List.of("validToken"));
+        BatchResponse batchResponse = mock(BatchResponse.class);
+        SendResponse sendResponse = mock(SendResponse.class);
 
-            BatchResponse batchResponse = mock(BatchResponse.class);
-            SendResponse sendResponse = mock(SendResponse.class);
+        given(fcmRetryExecutor.sendEach(anyList())).willReturn(batchResponse);
+        given(batchResponse.getResponses()).willReturn(List.of(sendResponse));
+        given(sendResponse.isSuccessful()).willReturn(true);
 
-            given(messaging.sendEach(anyList(), eq(true))).willReturn(batchResponse);
-            given(batchResponse.getResponses()).willReturn(List.of(sendResponse));
-            given(sendResponse.isSuccessful()).willReturn(true);
+        // when
+        fcmSender.sendNotification(alarmMessages);
 
-            // when
-            fcmSender.sendNotification(alarmMessages);
-
-            // then
-            verify(messaging, times(1)).sendEach(anyList(), eq(true));
-        }
+        // then
+        verify(fcmRetryExecutor, times(1)).sendEach(anyList());
     }
 
     @Test
     @DisplayName("만료된 토큰(UNREGISTERED) 에러코드 반환 시 토큰 삭제 매니저 호출")
     void sendNotification_FAIL_DELETE() throws Exception {
-        try (MockedStatic<FirebaseMessaging> mockFirebase = mockStatic(FirebaseMessaging.class)) {
-            // given
-            FirebaseMessaging messaging = mock(FirebaseMessaging.class);
-            mockFirebase.when(FirebaseMessaging::getInstance).thenReturn(messaging);
+        // given
+        String expiredToken = "expiredToken";
+        Message message = Message.builder().setToken(expiredToken).build();
+        AlarmMessages alarmMessages = new AlarmMessages(List.of(message), List.of(expiredToken));
 
-            String expiredToken = "expiredToken";
-            Message message = Message.builder().setToken(expiredToken).build();
-            AlarmMessages alarmMessages = new AlarmMessages(List.of(message), List.of(expiredToken));
+        BatchResponse batchResponse = mock(BatchResponse.class);
+        SendResponse sendResponse = mock(SendResponse.class);
+        FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
 
-            BatchResponse batchResponse = mock(BatchResponse.class);
-            SendResponse sendResponse = mock(SendResponse.class);
-            FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+        given(fcmRetryExecutor.sendEach(anyList())).willReturn(batchResponse);
+        given(batchResponse.getResponses()).willReturn(List.of(sendResponse));
+        given(sendResponse.isSuccessful()).willReturn(false);
+        given(sendResponse.getException()).willReturn(exception);
+        given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.UNREGISTERED);
 
-            given(messaging.sendEach(anyList(), eq(true))).willReturn(batchResponse);
-            given(batchResponse.getResponses()).willReturn(List.of(sendResponse));
-            given(sendResponse.isSuccessful()).willReturn(false);
-            given(sendResponse.getException()).willReturn(exception);
-            given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.UNREGISTERED);
+        // when
+        fcmSender.sendNotification(alarmMessages);
 
-            // when
-            fcmSender.sendNotification(alarmMessages);
+        // then
+        verify(fcmManager, times(1)).removeAll(List.of(expiredToken));
+    }
 
-            // then
-            verify(fcmRepository, times(1)).deleteAll(List.of(expiredToken));
-        }
+    @Test
+    @DisplayName("네트워크 오류(UNAVAILABLE) 에러코드 반환 시 재시도 sendEach 호출")
+    void sendNotification_RETRY() throws Exception {
+        // given
+        String token = "retryToken";
+        Message message = Message.builder().setToken(token).build();
+        AlarmMessages alarmMessages = new AlarmMessages(List.of(message), List.of(token));
+
+        BatchResponse batchResponse = mock(BatchResponse.class);
+        SendResponse sendResponse = mock(SendResponse.class);
+        FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+
+        given(fcmRetryExecutor.sendEach(anyList())).willReturn(batchResponse);
+        given(batchResponse.getResponses()).willReturn(List.of(sendResponse));
+        given(sendResponse.isSuccessful()).willReturn(false);
+        given(sendResponse.getException()).willReturn(exception);
+        given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.UNAVAILABLE);
+
+        // when
+        fcmSender.sendNotification(alarmMessages);
+
+        // then
+        verify(fcmRetryExecutor, times(2)).sendEach(anyList());
+    }
+
+    @Test
+    @DisplayName("fcmRetryExecutor.sendEach 예외 발생 시 경고 로그만 출력하고 종료")
+    void sendNotification_EXCEPTION() throws Exception {
+        // given
+        Message message = Message.builder().setToken("token").build();
+        AlarmMessages alarmMessages = new AlarmMessages(List.of(message), List.of("token"));
+
+        FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+        given(fcmRetryExecutor.sendEach(anyList())).willThrow(exception);
+
+        // when
+        fcmSender.sendNotification(alarmMessages);
+
+        // then
+        verify(fcmManager, never()).removeAll(anyList());
+        verify(fcmRetryExecutor, times(1)).sendEach(anyList());
     }
 }


### PR DESCRIPTION
## 요약
@Retryable 어노테이션으로 재시도 로직 처리
네트워크 오류로 인한 전송 실패 처리 메시지 건들에 한해서 재시도 처리
재시도 3회 시도에도 실패하면 로그로 기록
## 변경사항(상세)